### PR TITLE
feat: GalleryLayout에 공통 속성 전달 기능 추가

### DIFF
--- a/app/events/page.jsx
+++ b/app/events/page.jsx
@@ -71,6 +71,7 @@ export default function Event() {
         enableTitle
         title={selectedType}
       />
+       {/* commonProps={{ enableInterest: false }}와 같이 공통으로 적용될 prop을 매개변수로 전달 가능 */}
       <GalleryLayout Component={EventGallery} items={eventData} />
     </>
   );

--- a/components/events/EventGallery.jsx
+++ b/components/events/EventGallery.jsx
@@ -3,10 +3,10 @@ import Gallery from "../global/Gallery"
 import { ICONS } from "@/constants/path"
 
 export default function EventGallery(
-  { imgSrc, alt, title = "제목", date = "0000.00.00 ~ 0000.00.00", location = "지역 및 장소명", isHot = false }
+  { imgSrc, alt, title = "제목", date = "0000.00.00 ~ 0000.00.00", location = "지역 및 장소명", isHot = false, enableInterest=true }
 ) {
   return (
-    <Gallery title={title} src={imgSrc} alt={alt}>
+    <Gallery title={title} src={imgSrc} alt={alt} enableInterest={enableInterest}>
       <div>
         {date}
       </div>

--- a/components/global/Gallery.jsx
+++ b/components/global/Gallery.jsx
@@ -4,10 +4,12 @@ import { ICONS, IMAGES } from "@/constants/path";
 import Image from "next/image";
 import { useState } from "react";
 
-export default function Gallery({ src, alt = "이미지", title = "제목 없음", onClick, children }) {
+export default function Gallery({ src, alt = "이미지", title = "제목 없음", enableInterest=true, onClick, children }) {
 
+  // 추후에 매개변수로 넘겨받아서 처리
   const [interest, setInterest] = useState(false);
 
+  // 이부분은 추후에 page에서 처리하는 방식으로 변경해야 할 듯
   const interestHandler = () => {
     setInterest(prev => !prev);
     if(typeof onClick == "function") onClick();
@@ -15,16 +17,18 @@ export default function Gallery({ src, alt = "이미지", title = "제목 없음
   
   return (
     <div className="bg-white w-[300px] relative" title={title}>
-      <button className={`absolute top-0 right-0 mt-4 mr-4 ${interest ? "" : "opacity-30"} hover:cursor-pointer`}
-        onClick={interestHandler}
-      >
-        <Image 
-          src={interest ? ICONS.HEART : ICONS.HEART_EMPTY}
-          alt="관심"
-          width={28}
-          height={28}
-        />
-      </button>
+      {enableInterest &&
+        <button className={`absolute top-0 right-0 mt-4 mr-4 ${interest ? "" : "opacity-30"} hover:cursor-pointer`}
+          onClick={interestHandler}
+        >
+          <Image 
+            src={interest ? ICONS.HEART : ICONS.HEART_EMPTY}
+            alt="관심"
+            width={28}
+            height={28}
+          />
+        </button>
+      }
       <div className="mx-[10px] py-[10px] overflow-hidden whitespace-nowrap text-ellipsis text-gray-400">
         <Image
           src={src ? src : IMAGES.GALLERY_DEFAULT_IMG}

--- a/components/global/GalleryLayout.jsx
+++ b/components/global/GalleryLayout.jsx
@@ -1,10 +1,10 @@
 import EventGallery from "../events/EventGallery";
 
-export default function GalleryLayout({ Component, items }) {
+export default function GalleryLayout({ Component, items, commonProps={} }) {
   return (
     <div className="grid grid-cols-[repeat(auto-fit,300px)] gap-0 justify-center">
       {items.map((item, idx) => (
-        <Component key={idx} {...item} />
+        <Component key={idx} {...item} {...commonProps} />
       ))}
     </div>
   )


### PR DESCRIPTION
`GalleryLayout`에 `commonProps`를 추가하여, 갤러리의 모든 아이템에 공통 속성을 한 번에 전달할 수 있도록 개선했습니다.
예를 들어, `commonProps`를 통해 모든 아이템의 관심 버튼 표시 여부를 한번에 제어할 수 있습니다.
commonProps={{ prop: value }} 형태로 전달.