### PR TITLE
fix: 커뮤니티 게시판 글쓰기/수정 UI 개선

### DIFF
--- a/app/community/page.jsx
+++ b/app/community/page.jsx
@@ -6,7 +6,6 @@ import Image from "next/image";
 
 import useLogin from "@/hooks/useLogin";
 import { ICONS } from "@/constants/path";
-import SlidingBanner from "@/components/community/SlidingBanner";
 import SearchBar from "@/components/global/SearchBar";
 import ListLayout from "@/components/global/ListLayout";
 import CommunityList from "@/components/community/CommunityList";
@@ -164,7 +163,17 @@ export default function CommunityListTablePage() {
       <h1 className="text-4xl font-bold py-[10px] h-16 px-6">{title}</h1>
       <p className="text-xl pt-[10px] h-12 fill-gray-600 px-6">{intro}</p>
 
-      <SlidingBanner />
+      <div className="w-screen relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] mb-8">
+        <div className="relative w-full h-[370px] overflow-hidden ">
+          <div className="min-w-full h-full relative flex-shrink-0">
+            <img
+              src={"/img/communitybanner.jpg"}
+              alt={"배너이미지"}
+              className="w-full h-full object-cover block"
+            />
+          </div>
+        </div>
+      </div>
 
       <div className="w-full mt-6 mb-2 flex items-center justify-end gap-3">
         <SearchBar
@@ -184,7 +193,7 @@ export default function CommunityListTablePage() {
             <option value="createdAt_asc">오래된순</option>
             <option value="comments_desc">댓글많은순</option>
             <option value="recommendations_desc">추천많은순</option>
-            <option value="views_desc">조회수많은순</option>
+            {/* <option value="views_desc">조회수많은순</option> */}
           </select>
 
           {ready && isLogined && (

--- a/app/community/write/page.jsx
+++ b/app/community/write/page.jsx
@@ -71,22 +71,28 @@ export default function CommunityWrite() {
           </div>
         )}
 
-        <div className="w-full mb-4">
+        <div className="w-full mb-6">
+          <label className="block text-lg font-medium text-gray-700 mb-2">
+            제목 <span className="text-red-500">*</span>
+          </label>
           <input
             type="text"
+            className="w-full h-12 px-4 border border-gray-300 rounded-lg bg-white text-sm focus:outline-none focus:border-blue-500"
             placeholder="제목을 입력해주세요"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="w-full h-12 px-4 border border-gray-300 rounded-lg bg-white text-sm focus:outline-none focus:border-blue-500"
           />
         </div>
 
-        <div className="w-full">
+        <div className="w-full mb-6">
+          <label className="block text-lg font-medium text-gray-700 mb-2">
+            내용
+          </label>
           <textarea
-            placeholder="내용을 입력해주세요"
             value={content}
             onChange={(e) => setContent(e.target.value)}
-            className="w-full min-h-[500px] p-4 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+            className="w-full h-64 px-4 py-3 border border-gray-300 rounded-lg bg-white text-sm focus:outline-none focus:border-blue-500 resize-none"
+            placeholder="내용을 입력해주세요"
           />
         </div>
 

--- a/app/mypage/post-manage/page.jsx
+++ b/app/mypage/post-manage/page.jsx
@@ -18,26 +18,30 @@ const fmtDate = (dt) => {
 };
 
 // Import the authenticated API instance
-import { api, unwrap } from '@/lib/apiBase';
+import { api, unwrap } from "@/lib/apiBase";
 
 const fetchMyBoards = async (memberId) => {
   try {
-    return await unwrap(
-      api.get(`/v1/board/author/${memberId}`)
-    );
+    const data = await unwrap(api.get(`/v1/board/author/${memberId}`));
+    // 최신글 먼저: createdAt 내림차순
+    return Array.isArray(data)
+      ? data.slice().sort((a, b) => {
+          const ta = new Date(a?.createdAt ?? 0).getTime();
+          const tb = new Date(b?.createdAt ?? 0).getTime();
+          return tb - ta;
+        })
+      : [];
   } catch (error) {
-    console.error('내 게시글 조회 실패:', error);
+    console.error("내 게시글 조회 실패:", error);
     throw error;
   }
 };
 
 const deleteBoard = async (boardId) => {
   try {
-    return await unwrap(
-      api.delete(`/v1/board/${boardId}`)
-    );
+    return await unwrap(api.delete(`/v1/board/${boardId}`));
   } catch (error) {
-    console.error('게시글 삭제 실패:', error);
+    console.error("게시글 삭제 실패:", error);
     throw error;
   }
 };
@@ -117,11 +121,11 @@ export default function PostManage() {
         <div className="mt-6">
           <div
             className="grid border-b mb-2 text-sm py-3 px-4  bg-gray-50"
-            style={{ gridTemplateColumns: "1fr 60px 60px 60px 300px 100px" }}>
+            style={{ gridTemplateColumns: "1fr 60px 60px  300px 100px" }}>
             <div className="text-left">제목</div>
             <div className="text-center">댓글</div>
             <div className="text-center">추천</div>
-            <div className="text-center">조회</div>
+            {/* <div className="text-center">조회</div> */}
             <div className="text-center px-2">작성일</div>
             <div></div>
           </div>
@@ -136,7 +140,7 @@ export default function PostManage() {
                 key={r.id}
                 className="grid items-center py-3 px-4 border-b text-sm hover:bg-gray-50"
                 style={{
-                  gridTemplateColumns: "1fr 60px 60px 60px 300px 100px",
+                  gridTemplateColumns: "1fr 60px 60px  300px 100px",
                 }}>
                 <div className="text-left">
                   <Link
@@ -149,7 +153,7 @@ export default function PostManage() {
 
                 <div className="text-center">{r.comments}</div>
                 <div className="text-center">{r.recommends}</div>
-                <div className="text-center">{r.views}</div>
+                {/* <div className="text-center">{r.views}</div> */}
                 <div className="text-center text-gray-500 px-2 whitespace-nowrap">
                   {r.date}
                 </div>

--- a/components/community/CommunityList.jsx
+++ b/components/community/CommunityList.jsx
@@ -12,24 +12,22 @@ function fmtDate(iso) {
   )}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 }
 
-export default function CommunityList({ 
-  id, 
-  title, 
-  author, 
-  createdAt, 
-  views, 
-  recommendations, 
-  comments 
+export default function CommunityList({
+  id,
+  title,
+  author,
+  createdAt,
+  // views,
+  recommendations,
+  comments,
 }) {
   return (
     <div
       className="grid hover:bg-gray-50 bg-white py-3 px-4 border-b border-gray-300 transition-colors duration-150"
       style={{
-        gridTemplateColumns: "140px 1fr 60px 60px 60px 200px",
+        gridTemplateColumns: "140px 1fr 60px 60px  200px",
       }}>
-      <div
-        className="text-sm text-gray-800 text-left truncate"
-        title={author}>
+      <div className="text-sm text-gray-800 text-left truncate" title={author}>
         {author}
       </div>
       <div className="min-w-0">
@@ -40,15 +38,11 @@ export default function CommunityList({
           {title}
         </Link>
       </div>
-      <div className="text-center text-sm text-gray-600">
-        {comments}
-      </div>
-      <div className="text-center text-sm text-gray-600">
-        {recommendations}
-      </div>
-      <div className="text-center text-sm text-gray-600">
+      <div className="text-center text-sm text-gray-600">{comments}</div>
+      <div className="text-center text-sm text-gray-600">{recommendations}</div>
+      {/* <div className="text-center text-sm text-gray-600">
         {views}
-      </div>
+      </div> */}
       <div className="text-center text-xs text-gray-400">
         {fmtDate(createdAt)}
       </div>

--- a/components/community/CommunityTableHeader.jsx
+++ b/components/community/CommunityTableHeader.jsx
@@ -4,12 +4,12 @@ export default function CommunityTableHeader() {
   return (
     <div
       className="grid border-b-2 border-gray-200 mb-4 text-sm py-3 px-4 text-center bg-gray-50 font-semibold"
-      style={{ gridTemplateColumns: "140px 1fr 60px 60px 60px 200px" }}>
+      style={{ gridTemplateColumns: "140px 1fr 60px 60px 200px" }}>
       <div className="text-left">작성자명</div>
       <div className="text-left">제목</div>
       <div className="text-center">댓글수</div>
       <div className="text-center">추천수</div>
-      <div className="text-center">조회수</div>
+      {/* <div className="text-center">조회수</div> */}
       <div className="text-center">작성일</div>
     </div>
   );

--- a/components/community/CommunityWriteOption.jsx
+++ b/components/community/CommunityWriteOption.jsx
@@ -3,7 +3,7 @@
 /** 자유게시판 글 작성 옵션박스 */
 
 import SearchToWrite from "./SearchToWrite";
-import AddContent from "./AddContent";
+// import AddContent from "./AddContent";
 import Link from "next/link";
 
 export default function CommunityWriteOption({ onPickEvent = () => {} }) {
@@ -28,16 +28,14 @@ export default function CommunityWriteOption({ onPickEvent = () => {} }) {
       </div>
 
       {/* 컨텐츠 추가 */}
-      <div className="flex items-center">
+      {/* <div className="flex items-center">
         <span className="text-sm text-gray-700 w-32 flex-shrink-0">
           컨텐츠 추가
         </span>
         <div className="flex-1 ml-[20px]">
           <AddContent />
         </div>
-      </div>
-
-      {/* 글쓰기 방식 */}
+      </div> */}
     </div>
   );
 }

--- a/components/community/SearchToWrite/EventTile.jsx
+++ b/components/community/SearchToWrite/EventTile.jsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 
 import StarScore from "@/lib/StarScore";
 import { ICONS } from "@/constants/path";
+import { getEventTypeLabel } from "@/lib/api/eventApi";
 
 export default function EventTile({ card, onPick }) {
   const { eventImage, eventType, eventName, description, starScore = 0 } = card;
@@ -28,7 +29,7 @@ export default function EventTile({ card, onPick }) {
       {/* 본문 */}
       <div className="mt-3 flex-1 min-h-0">
         <span className="inline-flex items-center px-2 py-0.5 text-[11px] rounded-full border text-blue-600 bg-blue-50">
-          {eventType}
+          {getEventTypeLabel(eventType)}
         </span>
         <div className="mt-1 font-semibold text-[15px] leading-tight line-clamp-1">
           {eventName}

--- a/components/global/PostEventMiniCard.jsx
+++ b/components/global/PostEventMiniCard.jsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Image from "next/image";
 import { ICONS } from "@/constants/path";
 import StarScore from "@/lib/StarScore";
+import { getEventTypeLabel } from "@/lib/api/eventApi";
 
 export default function PostEventMiniCard({
   eventImage = "/img/default_img.svg", // 기본 디폴트 이미지
@@ -37,24 +38,18 @@ export default function PostEventMiniCard({
   };
 
   return (
-    <div 
+    <div
       className={`bg-white border border-gray-200 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200 overflow-hidden w-full ${
-        onClick ? 'cursor-pointer' : ''
+        onClick ? "cursor-pointer" : ""
       }`}
-      onClick={onClick}
-    >
+      onClick={onClick}>
       {/* 가로 레이아웃: 이미지 왼쪽 + 콘텐츠 오른쪽 */}
       <div className="flex">
         {/* 왼쪽 이미지 영역 - 세로 가운데 정렬 */}
-        <div className="w-32 h-40 bg-white flex-shrink-0 p-2">
+        <div className="w-32 h-40 bg-white flex-shrink-0 p-2 mb-2 ml-2">
           <div className="relative w-full h-full">
             {/* eslint-disable-next-line @next/next/no-img-element 이미지 경고제거 주석*/}
-            <Image
-              src={eventImage}
-              alt={alt}
-              fill
-              className="object-cover rounded"
-            />
+            <Image src={eventImage} alt={alt} fill className="object-cover" />
           </div>
         </div>
 
@@ -63,7 +58,7 @@ export default function PostEventMiniCard({
           {/* 상단: 이벤트 타입과 이름 */}
           <div className="flex items-center gap-2 mb-2">
             <span className="px-2 py-1 bg-blue-100 text-blue-600 text-xs rounded-full border">
-              {eventType}
+              {getEventTypeLabel(eventType)}
             </span>
             <span className="text-gray-600 text-sm font-medium">
               {eventName}

--- a/lib/api/eventApi.js
+++ b/lib/api/eventApi.js
@@ -343,11 +343,11 @@ export const getUserInterestEvents = async () => {
       credentials: "include",
       headers,
     });
-    
+
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}: ${res.statusText}`);
     }
-    
+
     return await res.json();
   } catch (e) {
     console.error("[getUserInterestEvents] fetch failed:", url, e);
@@ -421,7 +421,7 @@ export const EVENT_TYPES = {
   MOVIE: "MOVIE",
   THEATER: "THEATER",
   EXHIBITION: "EXHIBITION",
-  CLASSICAL: "Classical",
+  CLASSIC: "CLASSIC",
   DANCE: "DANCE",
   CONCERT: "CONCERT",
   FESTIVAL: "FESTIVAL",
@@ -434,7 +434,7 @@ export const EVENT_TYPE_LABELS = {
   [EVENT_TYPES.MOVIE]: "영화",
   [EVENT_TYPES.THEATER]: "연극",
   [EVENT_TYPES.EXHIBITION]: "전시회",
-  [EVENT_TYPES.CLASSICAL]: "클래식",
+  [EVENT_TYPES.CLASSIC]: "클래식",
   [EVENT_TYPES.DANCE]: "무용",
   [EVENT_TYPES.CONCERT]: "콘서트",
   [EVENT_TYPES.FESTIVAL]: "페스티벌",


### PR DESCRIPTION
- 글쓰기/수정 페이지 폼 필드에 라벨 추가
- 이벤트 카드 복원 로직 추가로 수정 시 선택된 이벤트 정보 유지
- 조회수 컬럼 제거로 UI 단순화
- 커뮤니티 배너를 SlidingBanner에서 정적 이미지로 변경
- 게시글 상세페이지에 수정 버튼 추가
- 이벤트 타입 라벨링 통일 및 로그아웃 로직 정리