### PR TITLE
fix: 토큰 만료 시간과 로그인 만료 시간 불일치 해결

### DIFF
--- a/lib/apiBase.js
+++ b/lib/apiBase.js
@@ -90,6 +90,13 @@ api.interceptors.response.use(
           localStorage.removeItem(KEY_V2);
           localStorage.removeItem(KEY_V1);
           localStorage.removeItem("accessToken");
+          localStorage.removeItem("auth_session_v2"); // 세션 정보도 함께 제거
+          localStorage.removeItem("auth_session_v1"); // 구버전 호환
+
+          // 로그인 페이지로 리다이렉트 (선택사항)
+          // if (typeof window !== 'undefined' && window.location.pathname !== '/login') {
+          //   window.location.href = '/login';
+          // }
         } catch {}
       }
 


### PR DESCRIPTION
  - JWT: 24시간으로 통일, remember에 따라 1일/7일이던 불일치 해결
    - remember의 의미가 없어짐. 추후 refresh token 구현
  - 401 에러 발생 시 세션 정보도 함께 제거하여 완전한 로그아웃 처리
  - 페이지 새로고침 시 토큰 만료 체크 로직 강화

  해결된 문제:
  - 토큰은 만료되었지만 프론트엔드에서 로그인 상태로 표시
  - API 호출 시 지속적인 401 에러 발생
  - 자동 로그인 체크 여부와 관계없이 24시간 후 로그아웃으로 통일